### PR TITLE
urgent Fix.: retry once until gen video availability

### DIFF
--- a/.env.config.dev
+++ b/.env.config.dev
@@ -14,3 +14,4 @@ VIDEO_LIST_FILE_NAME = "videos_to_merge.txt"
 NB_WORDS_PER_SUBTITLE = 15
 NB_SECONDS_PER_WORDS = 0.5
 DEFAULT_BACKGROUND_MUSIC = medias/royalteefree_background_music.mp3
+MEDIA_POLLING_INTERVAL = 5

--- a/tests/test_filetools.py
+++ b/tests/test_filetools.py
@@ -23,7 +23,6 @@ import tests.testing_medias as testing_medias
 from vikit.common.context_managers import WorkingFolderContext
 from vikit.common.file_tools import (
     download_or_copy_file,
-    wait_for_file_availability,
 )
 
 logger.add("log_test_Filetools.txt", rotation="10 MB")
@@ -53,30 +52,3 @@ class TestFileTools:
             assert downloaded_file != ""
             assert os.path.exists(downloaded_file)
             assert os.path.getsize(downloaded_file) > 0
-
-    @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_video_building_handler_success(self):
-        url = await wait_for_file_availability(
-            url="https://www.google.com", interval_sleep_time=1, max_attempts=10
-        )
-        assert url == "https://www.google.com"
-
-    @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_video_building_handler_raising_timeout_exception(self):
-        with pytest.raises(TimeoutError):
-            await wait_for_file_availability("https://example.invalid", 1, 3)
-
-    @pytest.mark.local_integration
-    @pytest.mark.asyncio
-    async def test_video_building_handler_immediate_success(self):
-        with WorkingFolderContext():
-            with open("test.txt", "w") as f:
-                f.write("test")
-            url = await wait_for_file_availability("file://test.txt", 1, 2)
-            assert url == "file://test.txt"
-
-
-# We need a more advanced test here but it requires a more complex setup with parralel threads
-# and synchronization between them. We will implement it in the future.

--- a/tests/test_filetools.py
+++ b/tests/test_filetools.py
@@ -21,14 +21,17 @@ from loguru import logger
 
 import tests.testing_medias as testing_medias
 from vikit.common.context_managers import WorkingFolderContext
-from vikit.common.file_tools import download_or_copy_file
+from vikit.common.file_tools import (
+    download_or_copy_file,
+    wait_for_file_availability,
+)
+
+logger.add("log_test_Filetools.txt", rotation="10 MB")
+warnings.simplefilter("ignore", category=UserWarning)
+warnings.simplefilter("ignore", ResourceWarning)
 
 
 class TestFileTools:
-    def setup():
-        logger.add("log_test_Filetools.txt", rotation="10 MB")
-        warnings.simplefilter("ignore", category=UserWarning)
-        warnings.simplefilter("ignore", ResourceWarning)
 
     @pytest.mark.local_integration
     @pytest.mark.asyncio
@@ -50,3 +53,30 @@ class TestFileTools:
             assert downloaded_file != ""
             assert os.path.exists(downloaded_file)
             assert os.path.getsize(downloaded_file) > 0
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_video_building_handler_success(self):
+        url = await wait_for_file_availability(
+            url="https://www.google.com", interval_sleep_time=1, max_attempts=10
+        )
+        assert url == "https://www.google.com"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_video_building_handler_raising_timeout_exception(self):
+        with pytest.raises(TimeoutError):
+            await wait_for_file_availability("https://example.invalid", 1, 3)
+
+    @pytest.mark.local_integration
+    @pytest.mark.asyncio
+    async def test_video_building_handler_immediate_success(self):
+        with WorkingFolderContext():
+            with open("test.txt", "w") as f:
+                f.write("test")
+            url = await wait_for_file_availability("file://test.txt", 1, 2)
+            assert url == "file://test.txt"
+
+
+# We need a more advanced test here but it requires a more complex setup with parralel threads
+# and synchronization between them. We will implement it in the future.

--- a/tests/test_video_building_handlers.py
+++ b/tests/test_video_building_handlers.py
@@ -21,19 +21,19 @@ from loguru import logger
 from tests.testing_medias import get_test_prompt_recording_trainboy
 from vikit.common.context_managers import WorkingFolderContext
 from vikit.prompt.recorded_prompt import RecordedPrompt
-from vikit.video.building.handlers.use_prompt_audio_track_and_audio_merging_handler import \
-    UsePromptAudioTrackAndAudioMergingHandler
+from vikit.video.building.handlers.use_prompt_audio_track_and_audio_merging_handler import (
+    UsePromptAudioTrackAndAudioMergingHandler,
+)
 from vikit.video.building.handlers.videogen_handler import VideoGenHandler
 from vikit.video.raw_text_based_video import RawTextBasedVideo
 from vikit.video.video_build_settings import VideoBuildSettings
 
+warnings.simplefilter("ignore", category=ResourceWarning)
+warnings.simplefilter("ignore", category=UserWarning)
+logger.add("log_test_video_building_handlers.txt", rotation="10 MB")
 
-class TestVideoBuildingHandler:
 
-    def setUp(self) -> None:
-        warnings.simplefilter("ignore", category=ResourceWarning)
-        warnings.simplefilter("ignore", category=UserWarning)
-        logger.add("log_test_video_building_handlers.txt", rotation="10 MB")
+class TestVideoBuildingHandlers:
 
     @pytest.mark.local_integration
     @pytest.mark.asyncio

--- a/vikit/common/config.py
+++ b/vikit/common/config.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 
 import os
-from concurrent.futures import ProcessPoolExecutor
 from os import path
 
 from dotenv import load_dotenv
@@ -29,6 +28,13 @@ if not os.path.exists(env_file):
     logger.warning(f"config file {env_file} does not exist")
 else:
     load_dotenv(dotenv_path=env_file)
+
+
+def get_media_polling_interval() -> int:
+    media_polling_interval = os.getenv("MEDIA_POLLING_INTERVAL", 10)
+    if media_polling_interval is None:
+        raise Exception("MEDIA_POLLING_INTERVAL is not set")
+    return int(media_polling_interval)
 
 
 def get_default_background_music() -> str:

--- a/vikit/common/file_tools.py
+++ b/vikit/common/file_tools.py
@@ -155,30 +155,6 @@ def url_exists(url: str):
     return url_exists
 
 
-async def wait_for_file_availability(
-    url: str, interval_sleep_time: int = 1, max_attempts: int = 10
-):
-    """
-    Wait for the file to be available.
-
-    Args:
-        url (str): The URL of the file to wait for
-        sleep_time (int): The time to wait between each check
-        max_attempts (int): The maximum number of attempts to check the URL
-    """
-    attempts = 0
-    while True and attempts < max_attempts:
-        if url_exists(url):
-            break
-        await asyncio.sleep(interval_sleep_time)
-        attempts += 1
-
-    if attempts >= max_attempts:
-        raise TimeoutError(f"File {url} not available after {max_attempts} attempts")
-
-    return url
-
-
 def is_valid_path(path: Optional[Union[str, os.PathLike]]) -> bool:
     """
     Check if the path is valid: could be a local path or a remote one

--- a/vikit/video/building/handlers/videogen_handler.py
+++ b/vikit/video/building/handlers/videogen_handler.py
@@ -30,6 +30,11 @@ class VideoGenHandler(Handler):
         Process the video generation binaries: the video binary is generated from Gen AI, hosted behind an API
         which could be distant as well as local. The video binary is then stored in a web storage or locally.
 
+        Important: The video generation is a long process, so it is executed asynchronously. Depending on the platform
+        providing it, the video generation could take a few seconds to a few minutes, and the video binary might not be
+        available immediately even though a URL is returned. This is not an issue on this handler but it might
+        be for subsequent handlers as they will need to reprocess the video.
+
         Args:
             video (Video): The video to process
 

--- a/vikit/video/building/handlers/videogen_handler.py
+++ b/vikit/video/building/handlers/videogen_handler.py
@@ -14,9 +14,14 @@
 # ==============================================================================
 
 from loguru import logger
+import time
 
 from vikit.common.handler import Handler
 from vikit.video.video import Video
+from vikit.common.config import get_media_polling_interval
+from vikit.common.file_tools import (
+    url_exists,
+)
 
 
 class VideoGenHandler(Handler):
@@ -53,6 +58,18 @@ class VideoGenHandler(Handler):
                 )
             )
         )
+
+        if not url_exists(video.media_url):
+            logger.warning(
+                f"Media URL {self.metadata.media_url} is not available yet, waiting for it for {get_media_polling_interval()} seconds"
+            )
+            time.sleep(get_media_polling_interval())
+            if url_exists(video.media_url):
+                return video.media_url
+            else:
+                logger.error(
+                    f"Media URL {self.metadata.media_url} is not available yet, the related video will need to be generated after the overall video generation process"
+                )
 
         logger.debug(f"Video generated from prompt: {video.media_url}")
         return video

--- a/vikit/video/video.py
+++ b/vikit/video/video.py
@@ -16,20 +16,17 @@
 import os
 import random
 import shutil
-import time
 import uuid as uid
 from abc import ABC, abstractmethod
 import re
 
 from loguru import logger
 
-from vikit.common.config import get_media_polling_interval
 from vikit.common.decorators import log_function_params
 from vikit.common.file_tools import (
     download_or_copy_file,
     is_valid_filename,
     is_valid_path,
-    url_exists,
 )
 from vikit.common.handler import Handler
 from vikit.video.building.video_building_pipeline import VideoBuildingPipeline


### PR DESCRIPTION
Urgent Fix, for video only: a video generation model might send an URL too early, i.e. before the video is actually generated and available. This causes the overall video generation process to fail.
Here we fix this by checking the actual presence of the video file after we get an URL back from video generation API. If not we wait for a 5s delay (this can be changed by changing MEDIA_POLLING_INTERVAL env var) and check again
If the URL is find, all good, otherwise we simply log an error and let the flow continue to generate the other videos. We take the assumption that this case is very unlikely to happen until we fix the video availability issue by polling the API properly, which depends on the API / platform, or use webhooks.