### PR TITLE
fix: always use google.cloud.storage library to download from GCS

### DIFF
--- a/vikit/common/file_tools.py
+++ b/vikit/common/file_tools.py
@@ -257,14 +257,14 @@ async def download_or_copy_file(url, local_path, force_download=False):
         url = gs_url
 
     path_desc, error = get_path_type(url)
+    if error:
+        raise ValueError(f"Unsupported remote path type: {url} with error: {error}")
+
     if len(local_path) > 255:
         local_path = local_path[-255:]
     if os.path.exists(local_path) and not force_download:
         logger.debug(f"File already exists at {local_path}, skipping download")
         return local_path
-
-    if error:
-        raise ValueError(f"Unsupported remote path type: {url} with error: {error}")
 
     if path_desc["type"] == "http" or path_desc["type"] == "https":
         async with aiohttp.ClientSession() as session:

--- a/vikit/common/file_tools.py
+++ b/vikit/common/file_tools.py
@@ -34,7 +34,7 @@ from vikit.common.config import get_nb_retries_http_calls
 
 TIMEOUT = 10  # seconds before stopping the request to check an URL exists
 
-# A regex that matches Google Cloud Storage URLs. It matches the following pattern:
+# A regex that matches Google Cloud Storage URLs. It matches the following patterns:
 # http://storage.googleapis.com/<file_path>
 # https://storage.googleapis.com/<file_path>
 GOOGLE_STORAGE_URL_PATTERN = r"https?://storage\.googleapis\.com/(.*)"
@@ -249,7 +249,7 @@ async def download_or_copy_file(url, local_path, force_download=False):
         raise ValueError("URL must be provided")
 
     # Replace the Google Cloud Storage URL with the gs:// format in order to take
-    # advantage of the copy_file_from_gcs function as much as possible.
+    # advantage of the google.cloud.storage library as much as possible.
     match = re.match(GOOGLE_STORAGE_URL_PATTERN, url)
     if match:
         gs_url = "gs://" + match.group(1)

--- a/vikit/common/file_tools.py
+++ b/vikit/common/file_tools.py
@@ -261,7 +261,12 @@ async def download_or_copy_file(url, local_path, force_download=False):
         raise ValueError(f"Unsupported remote path type: {url} with error: {error}")
 
     if len(local_path) > 255:
-        local_path = local_path[-255:]
+        truncated_path = local_path[-255:]
+        logger.warning(
+            "Local path is too long, truncating:"
+            f"\nold: {local_path}\nnew: {truncated_path}"
+        )
+        local_path = truncated_path
     if os.path.exists(local_path) and not force_download:
         logger.debug(f"File already exists at {local_path}, skipping download")
         return local_path


### PR DESCRIPTION
We implemented this as a workaround for an issue when downloading large files via HTTPS but we should consider keeping it in the long run if it makes our code more reliable.

The PR also restructures the download_or_copy_file function a little bit to make it more readable but without making any functional changes (except for the URL rewriting at the top).