### PR TITLE
Simplify outro appending to a video

### DIFF
--- a/tests/test_composite_video.py
+++ b/tests/test_composite_video.py
@@ -103,9 +103,9 @@ class TestCompositeVideo:
     ):
         with WorkingFolderContext():
             video = ImportedVideo(test_media.get_cat_video_path())
-            test_video_mixer = CompositeVideo()
-            test_video_mixer.append_video(video)
-            built = await test_video_mixer.build(
+            test_vidcomp = CompositeVideo()
+            test_vidcomp.append_video(video)
+            built_video = await test_vidcomp.build(
                 build_settings=VideoBuildSettings(
                     music_building_context=MusicBuildingContext(
                         apply_background_music=True, generate_background_music=True
@@ -118,7 +118,8 @@ class TestCompositeVideo:
                 ),
             )
 
-            assert built.media_url is not None
+            assert built_video is not None
+            assert built_video.media_url is not None
 
     @pytest.mark.local_integration
     @pytest.mark.asyncio

--- a/tests/test_ffmpeg_wrapper.py
+++ b/tests/test_ffmpeg_wrapper.py
@@ -55,7 +55,6 @@ class TestFFMPEGWrapper:
         """
 
         with WorkingFolderContext():
-            concat_file_name = "concatenate.txt"
             # Here we have to reencode the videos first
             catrix_reloaded = await reencode_video(
                 video_url=tests_medias.get_cat_video_path(),
@@ -66,19 +65,13 @@ class TestFFMPEGWrapper:
                 target_video_name="trainboy_reencoded.mp4",
             )
 
-            with open(concat_file_name, "w") as f:
-                f.write(f"file {catrix_reloaded}\n")
-                f.write(f"file {trainboy_reencoded}\n")
-
             generated_vid_file = await concatenate_videos(
-                input_file=concat_file_name,
+                video_file_paths=[catrix_reloaded, trainboy_reencoded],
                 target_file_name="target.mp4",
-                ratioToMultiplyAnimations=1,
+                ratio_to_multiply_animations=1,
             )
 
-            assert generated_vid_file is not None
             assert generated_vid_file == "target.mp4"
-            assert generated_vid_file != ""
             assert os.path.exists(generated_vid_file)
             assert os.path.getsize(generated_vid_file) > 0
 
@@ -94,20 +87,16 @@ class TestFFMPEGWrapper:
         """
 
         with WorkingFolderContext():
-            concat_file_name = "concatenate.txt"
-            with open(concat_file_name, "w") as f:
-                f.write(f"file {tests_medias.get_generated_3s_forest_video_2_path()}\n")
-                f.write(f"file {tests_medias.get_generated_3s_forest_video_1_path()}\n")
-
             generated_vid_file = await concatenate_videos(
-                input_file=concat_file_name,
+                video_file_paths=[
+                    tests_medias.get_generated_3s_forest_video_2_path(),
+                    tests_medias.get_generated_3s_forest_video_1_path(),
+                ],
                 target_file_name="target.mp4",
-                ratioToMultiplyAnimations=1,
+                ratio_to_multiply_animations=1,
             )
 
-            assert generated_vid_file is not None
             assert generated_vid_file == "target.mp4"
-            assert generated_vid_file != ""
             assert os.path.exists(generated_vid_file)
             assert os.path.getsize(generated_vid_file) > 0
 


### PR DESCRIPTION
- Removed calls to the compositevideo and useless calls to ML Gateway
Factory. This was ackward as we had to instanciate factories not to
really leverage them, as well as for the prompt, and do this in test
mode
- directly had to change a ffmpegwrapper function to concatenate videos
as it needed manipulating files instead of list of videos, preferred
doing this at lowest possible level
- now concatenate_videos function supports a list of videos

---------

Co-authored-by: JF Mac <jf@vikit,ai>
Co-authored-by: Nicolas Wettstein <nicolas@vikit.ai>
